### PR TITLE
DEV-6023 Fix insert-xref operations for cases where an xref is selected

### DIFF
--- a/src/operations-xref.json
+++ b/src/operations-xref.json
@@ -54,8 +54,14 @@
 				"data": {
 					"nodeName": "xref",
 					"attributes": {
+						"href": { "bindTo": "href" },
+						"format": { "bindTo": "format" },
+						"scope": { "bindTo": "scope" }
+					},
+					"model": {
 						"href": "{{reference}}",
-						"format": "dita"
+						"format": "dita",
+						"scope": null
 					}
 				}
 			}
@@ -75,6 +81,11 @@
 				"data": {
 					"nodeName": "xref",
 					"attributes": {
+						"href": { "bindTo": "href" },
+						"format": { "bindTo": "format" },
+						"scope": { "bindTo": "scope" }
+					},
+					"model": {
 						"href": "{{reference}}",
 						"format": "html",
 						"scope": "external"


### PR DESCRIPTION
These operations require all normal attributes in their stencil to match. In the old operations, during getState, the href would be
missing, so these operations would be disabled if another xref was in the selection with a different format attribute value. Furthermore, if an xref was in the selection with the same format, the operation would only work if the exact same href was selected (otherwise the stencil would not match during execution).

This fixes these operations to always override any existing xref in the selection. This is done by moving the actual attribute values to the stencil model, allowing the stencil to always match existing xrefs with any attribute value.

To make that work, the browse modal operations for these links had to be extended with dummy data in their getStateSteps, otherwise the reference would be left undefined, which is not allowed in a stencil model.

Also see FontoXML/dita-example-editor#34 - the changes in the dita-example-sx-integration package there are required for this to work!